### PR TITLE
Add ShareToken to funds

### DIFF
--- a/contracts/funds/FundFactory.sol
+++ b/contracts/funds/FundFactory.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.4.24;
 import './FundData.sol';
 import './FundFunctional.sol';
 import './FundRegistry.sol';
+import '../tokens/ShareToken.sol';
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 
 contract FundFactory is Ownable {
@@ -12,17 +13,37 @@ contract FundFactory is Ownable {
         fundRegistry = new FundRegistry();
     }
 
-    function createNewFund(address _fundOwner, string _fundName,
+    function createNewFund(
+        address _fundOwner,
+        string _fundName,
         uint32 _riskRating,
         int32 _pastAnnualReturns,
         uint32 _reputationRating,
-        string _description) onlyOwner public returns (FundFunctional) {
+        string _description,
+        string _symbol
+    ) onlyOwner public returns (FundFunctional) {
         FundData fundData = new FundData();
-        FundFunctional fund = new FundFunctional(fundData, _fundName);
+        ShareToken shares = new ShareToken(_fundName, _symbol);
+
+        FundFunctional fund = new FundFunctional(fundData, _fundName, shares);
+
+        shares.mint(fund, 1000);
+
         fundData.transferOwnership(fund);
+        shares.transferOwnership(fund);
+
         fund.transferOwnership(msg.sender);
-        fundRegistry.createNewFund(_fundOwner, fund, _fundName, _riskRating, _pastAnnualReturns, _reputationRating,
-            _description);
+
+        fundRegistry.createNewFund(
+            _fundOwner,
+            fund,
+            _fundName,
+            _riskRating,
+            _pastAnnualReturns,
+            _reputationRating,
+            _description
+        );
+
         return fund;
     }
 }

--- a/contracts/funds/FundFunctional.sol
+++ b/contracts/funds/FundFunctional.sol
@@ -2,15 +2,23 @@ pragma solidity ^0.4.24;
 
 import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import './FundData.sol';
+import '../tokens/ShareToken.sol';
 
 contract FundFunctional is Ownable {
+  // Due to Ownership chain, the FundFunctional contract is "owned" by
+  // the PortfolioFunctional contract, and thus is callable from there
+  // As the functions in the PortfolioFunctional contract require the
+  // caller to be the user, the functions here are only callable by the
+  // end user.
   string public fundName;
   FundData public fundData;
+  ShareToken public shares;
 
   // Constructor
-  constructor(address _fundData, string _fundName) public {
+  constructor(address _fundData, string _fundName, address _shares) public {
     fundName = _fundName;
     fundData = FundData(_fundData);
+    shares = ShareToken(_shares);
   }
 
   // Example of calling cross contract, not final business/application logic

--- a/contracts/tokens/ShareToken.sol
+++ b/contracts/tokens/ShareToken.sol
@@ -1,0 +1,61 @@
+/*
+    Implements ERC20 token
+*/
+
+pragma solidity ^0.4.24;
+
+import 'zeppelin-solidity/contracts/math/SafeMath.sol';
+import "zeppelin-solidity/contracts/token/ERC20/BurnableToken.sol";
+import "zeppelin-solidity/contracts/token/ERC20/MintableToken.sol";
+/// @title Asset Interface Contract
+/// @author Melonport AG <team@melonport.com>
+/// @notice This is to be considered as an interface on how to access the underlying Asset Contract
+/// @notice This extends the ERC20 Interface
+interface SharesInterface {
+
+    event Created(address indexed ofParticipant, uint atTimestamp, uint shareQuantity);
+    event Annihilated(address indexed ofParticipant, uint atTimestamp, uint shareQuantity);
+
+    // VIEW METHODS
+
+    function getName() view external returns (string);
+    function getSymbol() view external returns (string);
+    function getDecimals() view external returns (uint);
+    function getCreationTime() view external returns (uint);
+    function toSmallestShareUnit(uint quantity) view external returns (uint);
+    function toWholeShareUnit(uint quantity) view external returns (uint);
+}
+/**
+ * @title ShareToken
+ * @dev Akropolis Fund Share ERC20 Token.
+ */
+contract ShareToken is MintableToken, SharesInterface {
+    using SafeMath for uint256;
+
+    string public name;
+
+    uint8 public decimals;
+
+    string public symbol;
+
+    string public version;
+
+    uint public creationTime;
+
+    constructor(string _name, string _symbol) public {
+      name = _name;
+      symbol = _symbol;
+      decimals = 18;
+      version = 'Shares 1.0';
+      creationTime = now;
+    }
+
+
+    function getName() view returns (string) { return name; }
+    function getSymbol() view returns (string) { return symbol; }
+    function getDecimals() view returns (uint) { return decimals; }
+    function getCreationTime() view returns (uint) { return creationTime; }
+    function toSmallestShareUnit(uint quantity) view returns (uint) { return SafeMath.mul(quantity, 10 ** getDecimals()); }
+    function toWholeShareUnit(uint quantity) view returns (uint) { return quantity / (10 ** getDecimals()); }
+}
+

--- a/migrations/3_portfolio_and_funds_migration.js
+++ b/migrations/3_portfolio_and_funds_migration.js
@@ -17,9 +17,9 @@ module.exports = (deployer, network, accounts) => {
         await deployer.deploy(FundFactory);
         let factory = await FundFactory.deployed();
         let registry = FundRegistry.at(await factory.fundRegistry());
-        await factory.createNewFund(owner, "S&P500 Index", 100, 20, 50, "S&P500 index, capital + dividends", {from: owner});
-        await factory.createNewFund(owner, "Gold Investment", 20, 7, 80, "London gold fix in USD", {from: owner});
-        await factory.createNewFund(owner, "US State Bonds", 5, 3, 100, "US 10-year Treasury Bonds", {from: owner});
+        await factory.createNewFund(owner, "S&P500 Index", 100, 20, 50, "S&P500 index, capital + dividends", "SP500", {from: owner});
+        await factory.createNewFund(owner, "Gold Investment", 20, 7, 80, "London gold fix in USD", "GI", {from: owner});
+        await factory.createNewFund(owner, "US State Bonds", 5, 3, 100, "US 10-year Treasury Bonds", "USSB", {from: owner});
 
         let count = await registry.getFundCount();
         let funds = [];


### PR DESCRIPTION
This commit aims to add in a converted version of the MelonPort
share contract to our funds. The MelonPort contract relies on a
few libraries and patterns that differ from what we are using
(main issue is that they do not appear to use zeppelin). The major
differences between our ShareToken.sol and their Shares.sol are
firstly the change in math libraries (they use DSMath, we use
SafeMath), the custom minting/burning functions created (I have
therefore made use of the MintableToken/BurnableToken libraries
in zeppelin) and the return type of a few functions (they were
very strong on using byteX types, wheras we have been making use
of string types).

There has also been a comment added to the FundFunctional contract
to clarify who actually "owns" the contract with the current build
flow, to ensure that it is more immediately obvious to future users.